### PR TITLE
Remove deprecated set-output, write to $GITHUB_OUTPUT env file.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: |
         conan --version
-        echo "::set-output name=version::$(conan --version)"
+        echo "version=$(conan --version)" >> $GITHUB_OUTPUT
 branding:
   icon: "archive"
   color: "green"


### PR DESCRIPTION
Github action deprecated the used of `::set-output`.
I replaced it with the recommanded use of `$GITHUB_OUTPUT`, from: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 