### PR TITLE
Use HOME environment variable to build path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
       shell: bash
     - name: Fix path on Linux
       run: |
-        echo "/home/runner/.local/bin" >> $GITHUB_PATH
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
       shell: bash
     - name: Fill in output variable
       id: output_version


### PR DESCRIPTION
Self-hosted GitHub Runners could have any user as the github runner. Even multiple users/runners on a single machine like .e.g.
   /home/github-runner1
   /home/github-runner2
   ...
So lets use $HOME environment variable instead of hardcoded /home/runner.